### PR TITLE
`setup` variable in __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'tramway.tessellation.kdtree',
         'tramway.tessellation.kmeans',
         'tramway.inference',
+        'tramway.inference.bayes_factors',
         'tramway.feature',
         'tramway.plot',
         'tramway.plot.tk',

--- a/tramway/helper/base.py
+++ b/tramway/helper/base.py
@@ -76,6 +76,8 @@ class Helper(object):
                         self.analyses = Analyses(data)
                 else:
                     raise
+        elif isinstance(data, Analyses):
+            self.analyses = data
         if isinstance(data, Analyses):
             if not (labels is None and types is None):
                 data = find_artefacts(data, types, labels)
@@ -284,6 +286,8 @@ class Helper(object):
         if verbose is None:
             verbose = self.verbose
         output_file = self.output_file(output_file)
+        if output_file is None:
+            return
         if force is None and bool(self.input_file):
             if self.are_multiple_files(self.input_file):
                 input_files = list(self.input_file)

--- a/tramway/inference/bayes_factors/__init__.py
+++ b/tramway/inference/bayes_factors/__init__.py
@@ -16,7 +16,7 @@ def _bayes_factor(cells, localization_error=None, B_threshold=None, **kwargs):
         loc_error = localization_error
     # B_threshold
     if B_threshold is not None:
-        kwargs['B_treshold'] = B_threshold
+        kwargs['B_threshold'] = B_threshold
     ## iterate over the cells
     for i in cells:
         calculate_bayes_factors_for_one_cell(cells[i], loc_error, **kwargs)

--- a/tramway/inference/bayes_factors/__init__.py
+++ b/tramway/inference/bayes_factors/__init__.py
@@ -1,8 +1,17 @@
+import logging
 import sys
 from collections import OrderedDict
 
 from .calculate_bayes_factors import (calculate_bayes_factors,
                                       calculate_bayes_factors_for_one_cell)
+
+try:
+    from tqdm import tqdm
+except Exception:
+    logging.warning(
+        "Consider installing `tqdm` package (`pip install tqdm`) to see Bayes factors calculation progress.")
+
+    def tqdm(x): return x
 
 # The package can be imported by just `import bayes_factors`.
 __all__ = ['calculate_bayes_factors', 'calculate_bayes_factors_for_one_cell', 'setup']
@@ -23,7 +32,7 @@ def _bayes_factor(cells, localization_error=None, B_threshold=None, **kwargs):
         kwargs['B_threshold'] = B_threshold
 
     # iterate over the cells
-    for i in cells:
+    for i in tqdm(cells):
         calculate_bayes_factors_for_one_cell(cells[i], localization_error, **kwargs)
 
 

--- a/tramway/inference/bayes_factors/__init__.py
+++ b/tramway/inference/bayes_factors/__init__.py
@@ -1,33 +1,38 @@
-from .calculate_bayes_factors import calculate_bayes_factors, calculate_bayes_factors_for_one_cell
-
-# Only this function is supposed to be used publicly.
-# The package can be imported by just `import bayes_factors`.
-__all__ = ['calculate_bayes_factors', 'setup']
-
-
+import sys
 from collections import OrderedDict
 
+from .calculate_bayes_factors import (calculate_bayes_factors,
+                                      calculate_bayes_factors_for_one_cell)
+
+# The package can be imported by just `import bayes_factors`.
+__all__ = ['calculate_bayes_factors', 'calculate_bayes_factors_for_one_cell', 'setup']
+
+
+if sys.version_info <= (3, 5):
+    raise RuntimeError("Python 3.5+ is required for calculating Bayes factors")
+
+
 def _bayes_factor(cells, localization_error=None, B_threshold=None, **kwargs):
-    ## input arguments
+    # TODO: use the same localization error as for inference
+    # input arguments
     # loc_error
     if localization_error is None:
-        loc_error = 0.
-    else:
-        loc_error = localization_error
+        raise RuntimeError("Localization error must be specified for calculating Bayes factors")
     # B_threshold
     if B_threshold is not None:
         kwargs['B_threshold'] = B_threshold
-    ## iterate over the cells
+
+    # iterate over the cells
     for i in cells:
-        calculate_bayes_factors_for_one_cell(cells[i], loc_error, **kwargs)
+        calculate_bayes_factors_for_one_cell(cells[i], localization_error, **kwargs)
+
 
 setup = {
     'name': 'bayes_factor',
     'infer': '_bayes_factor',
     'arguments': OrderedDict((
-        ('localization_error', ('-e', dict(type=float, help='localization error'))),
+        ('localization_error', ('-e', dict(type=float, help='localization error (same units as the variance)'))),
         ('B_threshold', ('-b', dict(type=float, help='values of Bayes factor for thresholding'))),
-        )),
+    )),
     'returns': ['lg_B', 'force', 'min_n'],
-    }
-
+}

--- a/tramway/inference/bayes_factors/__init__.py
+++ b/tramway/inference/bayes_factors/__init__.py
@@ -1,6 +1,33 @@
-from .calculate_bayes_factors import calculate_bayes_factors
+from .calculate_bayes_factors import calculate_bayes_factors, calculate_bayes_factors_for_one_cell
 
 # Only this function is supposed to be used publicly.
 # The package can be imported by just `import bayes_factors`.
-__all__ = ['calculate_bayes_factors', 'calculate_bayes_factors_for_cells',
-           'calculate_bayes_factors_for_one_cell']
+__all__ = ['calculate_bayes_factors', 'setup']
+
+
+from collections import OrderedDict
+
+def _bayes_factor(cells, localization_error=None, B_threshold=None, **kwargs):
+    ## input arguments
+    # loc_error
+    if localization_error is None:
+        loc_error = 0.
+    else:
+        loc_error = localization_error
+    # B_threshold
+    if B_threshold is not None:
+        kwargs['B_treshold'] = B_threshold
+    ## iterate over the cells
+    for i in cells:
+        calculate_bayes_factors_for_one_cell(cells[i], loc_error, **kwargs)
+
+setup = {
+    'name': 'bayes_factor',
+    'infer': '_bayes_factor',
+    'arguments': OrderedDict((
+        ('localization_error', ('-e', dict(type=float, help='localization error'))),
+        ('B_threshold', ('-b', dict(type=float, help='values of Bayes factor for thresholding'))),
+        )),
+    'returns': ['lg_B', 'force', 'min_n'],
+    }
+

--- a/tramway/inference/bayes_factors/calculate_bayes_factors.py
+++ b/tramway/inference/bayes_factors/calculate_bayes_factors.py
@@ -9,9 +9,15 @@ import warnings
 import numpy as np
 import scipy
 from scipy.special import gammainc
-from tqdm import trange  # for graphical estimate of the progress
+try:
+    from tqdm import trange  # for graphical estimate of the progress
+except ImportError:
+    pass
 
-from stopwatch import stopwatch
+try:
+    from stopwatch import stopwatch
+except ImportError:
+    pass
 
 from .calculate_marginalized_integral import calculate_marginalized_integral
 from .convenience_functions import n_pi_func
@@ -47,7 +53,7 @@ def calculate_bayes_factors_for_one_cell(cell, loc_error, dim=2, B_threshold=10,
     V_pi = cell.V_prior
 
     cell.lg_B, cell.force, cell.min_n = _calculate_one_bayes_factor(
-        zeta_t=zeta_t, zeta_sp=zeta_sp, n=n, V=V, V_pi=V_prior, loc_error=loc_error, dim=dim, bl_need_min_n=True)
+        zeta_t=zeta_t, zeta_sp=zeta_sp, n=n, V=V, V_pi=V_pi, loc_error=loc_error, dim=dim, bl_need_min_n=True)
 
     return [cell.lg_B, cell.force, cell.min_n]
 
@@ -157,7 +163,7 @@ def calculate_minimal_n(zeta_t, zeta_sp, n0, V, V_pi, loc_error, dim=2, B_thresh
     # Define the Bayes factor
     def lg_B(n):
         """A wrapper for the Bayes factor as a function of n."""
-        lg_B, _ = _calculate_one_bayes_factor(
+        lg_B, _, _ = _calculate_one_bayes_factor(
             zeta_t=zeta_t, zeta_sp=zeta_sp, n=n, V=V, V_pi=V_pi, loc_error=loc_error, dim=dim, bl_need_min_n=False)
         return lg_B
 
@@ -189,7 +195,7 @@ def calculate_minimal_n(zeta_t, zeta_sp, n0, V, V_pi, loc_error, dim=2, B_thresh
 
     return min_n
 
-    def check_dimensionality(dim):
-        # Check dimensionality
-        if dim not in [2]:
-            raise ValueError(f"Bayes factor calculations in {dim}D not supported yet.")
+def check_dimensionality(dim):
+    # Check dimensionality
+    if dim not in [2]:
+        raise ValueError("Bayes factor calculations in {}D not supported yet.".format(dim))

--- a/tramway/inference/bayes_factors/calculate_bayes_factors.py
+++ b/tramway/inference/bayes_factors/calculate_bayes_factors.py
@@ -8,35 +8,34 @@ import warnings
 # from multiprocessing import Pool
 import numpy as np
 import scipy
-from scipy.special import gammainc
-try:
-    from tqdm import trange  # for graphical estimate of the progress
-except ImportError:
-    pass
-
-try:
-    from stopwatch import stopwatch
-except ImportError:
-    pass
 
 from .calculate_marginalized_integral import calculate_marginalized_integral
 from .convenience_functions import n_pi_func
 from .convenience_functions import p as pow
+from .stopwatch import stopwatch
+
+# from scipy.special import gammainc
 
 
-def calculate_bayes_factors_for_cells(cells, loc_error, dim=2, B_threshold=10, verbose=True):
-    """Calculate Bayes factors for an iterable ensemble of cells."""
+try:
+    from tqdm import trange  # for graphical estimate of the progress
+except ImportError:
+    trange = range
 
-    check_dimensionality(dim)
 
-    M = len(cells)
-    lg_Bs, forces, min_ns = [], [], []
-    for i, cell in enumerate(cells):
-        lg_Bs[i], forces[i], min_ns[i] = calculate_bayes_factors_for_one_cell(
-            cell, loc_error, dim=dim, B_threshold=B_threshold, verbose=verbose)
-        cell.lg_B, cell.force, cell.min_n = lg_Bs[i], forces[i], min_ns[i]
-
-    return [lg_Bs, forces, min_ns]
+# def calculate_bayes_factors_for_cells(cells, loc_error, dim=2, B_threshold=10, verbose=True):
+#     """Calculate Bayes factors for an iterable ensemble of cells."""
+#
+#     check_dimensionality(dim)
+#
+#     # M = len(cells)
+#     lg_Bs, forces, min_ns = [], [], []
+#     for i, cell in enumerate(cells):
+#         lg_Bs[i], forces[i], min_ns[i] = calculate_bayes_factors_for_one_cell(
+#             cell, loc_error, dim=dim, B_threshold=B_threshold, verbose=verbose)
+#         cell.lg_B, cell.force, cell.min_n = lg_Bs[i], forces[i], min_ns[i]
+#
+#     return [lg_Bs, forces, min_ns]
 
 
 def calculate_bayes_factors_for_one_cell(cell, loc_error, dim=2, B_threshold=10, verbose=True):
@@ -46,14 +45,15 @@ def calculate_bayes_factors_for_one_cell(cell, loc_error, dim=2, B_threshold=10,
 
     check_dimensionality(dim)
 
-    zeta_sp = cell.zeta_spurious
-    zeta_t = cell.zeta_total
-    n = cell.n
-    V = cell.V
-    V_pi = cell.V_prior
-
     cell.lg_B, cell.force, cell.min_n = _calculate_one_bayes_factor(
-        zeta_t=zeta_t, zeta_sp=zeta_sp, n=n, V=V, V_pi=V_pi, loc_error=loc_error, dim=dim, bl_need_min_n=True)
+        zeta_t=cell.zeta_total,
+        zeta_sp=cell.zeta_spurious,
+        n=cell.n,
+        V=cell.V,
+        V_pi=cell.V_prior,
+        loc_error=loc_error,
+        dim=dim,
+        bl_need_min_n=True)
 
     return [cell.lg_B, cell.force, cell.min_n]
 
@@ -91,12 +91,13 @@ def calculate_bayes_factors(zeta_ts, zeta_sps, ns, Vs, Vs_pi, loc_error, dim=2, 
 
     # Check that the 2nd dimension has size 2
     if np.shape(zeta_ts)[1] != 2 or np.shape(zeta_sps)[1] != 2:
-        raise VsalueError("zeta_ts and zeta_sps must be matrices of size (M x 2)")
+        raise ValueError("zeta_ts and zeta_sps must be matrices of size (M x 2)")
 
     M = len(ns)
 
     # Calculate
     lg_Bs = np.zeros_like(ns) * np.nan
+    forces = np.zeros_like(ns) * np.nan
     min_ns = np.zeros_like(ns, dtype=int) * np.nan
     with stopwatch("Bayes factor calculation", verbose):
         for i in trange(M):
@@ -155,8 +156,8 @@ def calculate_minimal_n(zeta_t, zeta_sp, n0, V, V_pi, loc_error, dim=2, B_thresh
     # Local constants
     increase_factor = 2  # initial search interval increase with each iteration
     max_attempts = 40
-    xtol = 0.1
-    rtol = 0.1
+    xtol = 1.0
+    rtol = 0.001
 
     lg_B_threshold = np.log10(B_threshold)
 
@@ -190,12 +191,12 @@ def calculate_minimal_n(zeta_t, zeta_sp, n0, V, V_pi, loc_error, dim=2, B_thresh
     def solve_me(n):
         return lg_B(n) - sign * lg_B_threshold
 
-    min_n = scipy.optimize.brentq(solve_me, n_interval[0], n_interval[1], xtol=1.0, rtol=0.001)
+    min_n = scipy.optimize.brentq(solve_me, n_interval[0], n_interval[1], xtol=xtol, rtol=rtol)
     min_n = np.int(np.ceil(min_n))
 
     return min_n
 
+
 def check_dimensionality(dim):
-    # Check dimensionality
     if dim not in [2]:
-        raise ValueError("Bayes factor calculations in {}D not supported yet.".format(dim))
+        raise ValueError("Bayes factor calculations in {dim}D not supported yet.".format(dim=dim))

--- a/tramway/inference/bayes_factors/calculate_bayes_factors.py
+++ b/tramway/inference/bayes_factors/calculate_bayes_factors.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright © 2018, Alexander Serov
 
 

--- a/tramway/inference/bayes_factors/calculate_marginalized_integral.py
+++ b/tramway/inference/bayes_factors/calculate_marginalized_integral.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright © 2018, Alexander Serov
 
 import numpy as np

--- a/tramway/inference/bayes_factors/calculate_marginalized_integral.py
+++ b/tramway/inference/bayes_factors/calculate_marginalized_integral.py
@@ -32,12 +32,12 @@ def calculate_marginalized_integral(zeta_t, zeta_sp, p, v, E, rel_loc_error):
 
     zeta_t, zeta_sp = map(np.asarray, [zeta_t, zeta_sp])
     if zeta_t.ndim > 1 or zeta_sp.ndim > 1:
-        raise ValueError(f"zeta_t and zeta_sp should be 1D vectors")
+        raise ValueError("zeta_t and zeta_sp should be 1D vectors")
 
     def arg(l):
         """lambda-dependent argument of the gamma function and the second term."""
         diff = l * zeta_sp - zeta_t
-        return v + E * (diff @ diff.T)
+        return v + E * (matmul(diff, diff.T))
 
     def get_integrate_me():
         """Function to integrate with and without localization error."""

--- a/tramway/inference/bayes_factors/calculate_marginalized_integral.py
+++ b/tramway/inference/bayes_factors/calculate_marginalized_integral.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 from scipy import integrate
-from scipy.special import gamma, gammainc, gammaincc
+from scipy.special import gammainc
 
 
 def calculate_marginalized_integral(zeta_t, zeta_sp, p, v, E, rel_loc_error):
@@ -37,7 +37,7 @@ def calculate_marginalized_integral(zeta_t, zeta_sp, p, v, E, rel_loc_error):
     def arg(l):
         """lambda-dependent argument of the gamma function and the second term."""
         diff = l * zeta_sp - zeta_t
-        return v + E * (matmul(diff, diff.T))
+        return v + E * (diff @ diff.T)
 
     def get_integrate_me():
         """Function to integrate with and without localization error."""

--- a/tramway/inference/bayes_factors/find_marginalized_zeta_t_roots.py
+++ b/tramway/inference/bayes_factors/find_marginalized_zeta_t_roots.py
@@ -1,10 +1,13 @@
+# -*- coding: utf-8 -*-
 
+# Copyright © 2018, Alexander Serov
 
-from .calculate_marginalized_integral import calculate_marginalized_integral
-from .convenience_functions import *
 # from log_C import log_C as log_C_func
 import numpy as np
 from scipy import optimize
+
+from .calculate_marginalized_integral import calculate_marginalized_integral
+from .convenience_functions import p
 
 
 def find_marginalized_zeta_t_roots(zeta_sp_par, n, n_pi, B, u, dim, zeta_t_perp):

--- a/tramway/inference/bayes_factors/stopwatch.py
+++ b/tramway/inference/bayes_factors/stopwatch.py
@@ -19,7 +19,7 @@ class stopwatch:
         self.end = time.time()
         delta = self.end - self.start
         if self.verbose:
-            print(f'\n{self.name} completed in {round(delta, 1)} s.\n')
+            print('\n{name} completed in {t} s.\n'.format(name=self.name, t=round(delta, 1)))
 
 
 # def stopwatch_dec(func):

--- a/tramway/inference/bayes_factors/stopwatch.py
+++ b/tramway/inference/bayes_factors/stopwatch.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018, Alexander Serov
+
+import time
+
+
+class stopwatch:
+    """A class for measuring execution time."""
+
+    def __init__(self, name, verbose=True):
+        self.name = name
+        self.verbose = verbose
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end = time.time()
+        delta = self.end - self.start
+        if self.verbose:
+            print(f'\n{self.name} completed in {round(delta, 1)} s.\n')
+
+
+# def stopwatch_dec(func):
+#     """An alternative decorator for measuring the elapsed time."""
+#
+#     def wrapper(*args, **kwargs):
+#         start = time.time()
+#         results = func(*args, **kwargs)
+#         delta = time.time() - start
+#         print(f'\n{self.name} completed in {round(delta, 1)} s.\n')
+#         return results
+#     return wrapper

--- a/tramway/inference/bayes_factors/test_calculate_bayes_factor.py
+++ b/tramway/inference/bayes_factors/test_calculate_bayes_factor.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright © 2018, Alexander Serov
 
 

--- a/tramway/inference/bayes_factors/test_calculate_bayes_factor.py
+++ b/tramway/inference/bayes_factors/test_calculate_bayes_factor.py
@@ -215,4 +215,4 @@ class bayes_test(unittest.TestCase):
 # # A dirty fix for a weird bug in unittest
 # if __name__ == '__main__':
 #     freeze_support()
-unittest.main()
+#unittest.main()

--- a/tramway/inference/bayes_factors/test_calculate_bayes_factor.py
+++ b/tramway/inference/bayes_factors/test_calculate_bayes_factor.py
@@ -9,8 +9,7 @@ from multiprocessing import freeze_support
 
 import numpy as np
 
-from .calculate_bayes_factors import (calculate_bayes_factors,
-                                      calculate_minimal_n)
+from .calculate_bayes_factors import calculate_bayes_factors
 from .calculate_marginalized_integral import calculate_marginalized_integral
 from .convenience_functions import n_pi_func, p
 
@@ -122,13 +121,13 @@ class bayes_test(unittest.TestCase):
         us = np.asarray([[0.95]])
         loc_error = 0.1**2.0
         Vs_pi = us * Vs
-        Bs, forces, _ = calculate_bayes_factors(
+        lg_Bs, forces, _ = calculate_bayes_factors(
             zeta_ts=zeta_ts, zeta_sps=zeta_sps, ns=ns, Vs=Vs, Vs_pi=Vs_pi, loc_error=loc_error)
         true_B = 0.2974282533
 
         # Check value
-        self.assertTrue(math.isclose(Bs[0], true_B, rel_tol=self.rel_tol, abs_tol=self.tol),
-                        "Bayes factor calculation failed for one bin. The obtained B = %.8g does not match the expected B = %.8g" % (Bs[0, 0], true_B))
+        self.assertTrue(math.isclose(10**lg_Bs[0], true_B, rel_tol=self.rel_tol, abs_tol=self.tol),
+                        "Bayes factor calculation failed for one bin. The obtained B = %.8g does not match the expected B = %.8g" % (10**lg_Bs[0, 0], true_B))
         # Check force presence
         self.assertTrue((true_B >= self.B_threshold) ==
                         forces[0], "Boolean conservative force return incorrect for the case of one bin")
@@ -141,13 +140,13 @@ class bayes_test(unittest.TestCase):
         us = np.asarray([[0.95]])
         loc_error = 0
         Vs_pi = us * Vs
-        Bs, forces, _ = calculate_bayes_factors(
+        lg_Bs, forces, _ = calculate_bayes_factors(
             zeta_ts=zeta_ts, zeta_sps=zeta_sps, ns=ns, Vs=Vs, Vs_pi=Vs_pi, loc_error=loc_error)
         true_B = 0.2974282533
 
         # Check value
-        self.assertTrue(math.isclose(Bs[0], true_B, rel_tol=self.rel_tol, abs_tol=self.tol),
-                        "Bayes factor calculation failed for one bin. The obtained B = %.8g does not match the expected B = %.8g" % (Bs[0, 0], true_B))
+        self.assertTrue(math.isclose(10**lg_Bs[0], true_B, rel_tol=self.rel_tol, abs_tol=self.tol),
+                        "Bayes factor calculation failed for one bin. The obtained B = %.8g does not match the expected B = %.8g" % (10**lg_Bs[0, 0], true_B))
         # Check force presence
         self.assertTrue((true_B >= self.B_threshold) ==
                         forces[0], "Boolean conservative force return incorrect for the case of one bin")
@@ -164,7 +163,7 @@ class bayes_test(unittest.TestCase):
         us = us.T
         Vs_pi = us * Vs
         N = len(ns)
-        Bs, forces, _ = calculate_bayes_factors(
+        lg_Bs, forces, _ = calculate_bayes_factors(
             zeta_ts=zeta_ts, zeta_sps=zeta_sps, ns=ns, Vs=Vs, Vs_pi=Vs_pi, loc_error=loc_error)
         true_Bs = [0.05997370802, 3.666049402e49, 1.378104868]
         # print(Bs)
@@ -172,8 +171,8 @@ class bayes_test(unittest.TestCase):
 
         for i in range(N):
             # Check value
-            self.assertTrue(np.isclose(Bs[i], true_Bs[i], rtol=self.rel_tol, atol=self.tol),
-                            "Bayes factor calculation failed for one bin. For bin no. %i, the obtained B = %.8g does not match the expected B = %.8g" % (i + 1, Bs[i], true_Bs[i]))
+            self.assertTrue(np.isclose(10**lg_Bs[i], true_Bs[i], rtol=self.rel_tol, atol=self.tol),
+                            "Bayes factor calculation failed for one bin. For bin no. %i, the obtained B = %.8g does not match the expected B = %.8g" % (i + 1, 10**lg_Bs[i], true_Bs[i]))
             # Check force presence
             true_forces = (1 * (np.log10(true_Bs[i]) >= np.log10(self.B_threshold)) -
                            1 * (np.log10(true_Bs[i]) <= -np.log10(self.B_threshold)))
@@ -197,22 +196,22 @@ class bayes_test(unittest.TestCase):
         Vs = Vs.T
         us = us.T
         Vs_pi = us * Vs
-        N = len(ns)
+        # N = len(ns)
 
         # Calculate min_ns
-        Bs, _, min_ns = calculate_bayes_factors(
+        lg_Bs, _, min_ns = calculate_bayes_factors(
             zeta_ts=zeta_ts, zeta_sps=zeta_sps, ns=ns, Vs=Vs, Vs_pi=Vs_pi, loc_error=loc_error)
         # Calculate Bs for min_ns to check
-        Bs, _, _ = calculate_bayes_factors(
+        lg_Bs, _, _ = calculate_bayes_factors(
             zeta_ts=zeta_ts, zeta_sps=zeta_sps, ns=min_ns, Vs=Vs, Vs_pi=Vs_pi, loc_error=loc_error)
 
         # Perform check
-        self.assertTrue(np.all(np.abs(np.log10(Bs[0])) >= np.log10(B_threshold)),
-                        "Not all of the Bayes factors for the minimal ns returned strong evidence. Bs: %s" % (Bs))
+        self.assertTrue(np.all(np.abs(lg_Bs[0]) >= np.log10(B_threshold)),
+                        "Not all of the Bayes factors for the minimal ns returned strong evidence. lg_Bs: %s" % (lg_Bs))
         # print(Bs)
 
 
 # # A dirty fix for a weird bug in unittest
 # if __name__ == '__main__':
 #     freeze_support()
-#unittest.main()
+# unittest.main()


### PR DESCRIPTION
Bayes factor integration into TRamWAy as a plugin.

`calculate_bayes_factors_for_cells` has been disregarded because attributes `lg_B`, `force` and `min_n` are set a second time there; first time in `calculate_bayes_factors_for_one_cell` is enough.

Most changes fix compatibility issues with older Python versions. Other changes are bug fixes.

The local tests have been discarded as they raise exceptions with PyTest.

Example usage of the plugin:

```
$ tramway tessellate hexagon -l "my hexagonal mesh" -i my_file.txt
$ tramway infer snr -l "snr (D mode)" --localization-error 0 -i my_file.rwa
$ tramway infer bayes_factor -L "my hexagonal mesh,snr (D mode)" -l "Bayes factors" -i my_file.rwa
$ tramway dump -i my_file.rwa
in my_file.rwa:
	<class 'pandas.core.frame.DataFrame'>
		'my hexagonal mesh' <class 'tramway.tessellation.base.CellStats'>
			'snr (D mode)' <class 'tramway.inference.base.Maps'>
				'Bayes factors' <class 'tramway.inference.base.Maps'>
$ tramway draw map -i my_file.rwa
```

or, to remove the snr maps from the file:

```
$ tramway tessellate hexagon -l "my hexagonal mesh" -i my_file.txt
$ tramway infer snr -l "Bayes factors" --localization-error 0 -i my_file.rwa
$ tramway infer bayes_factor -L "my hexagonal mesh,Bayes factors" --inplace -i my_file.rwa
$ tramway dump -i my_file.rwa
in my_file.rwa:
	<class 'pandas.core.frame.DataFrame'>
		'my hexagonal mesh' <class 'tramway.tessellation.base.CellStats'>
			'Bayes factors' <class 'tramway.inference.base.Maps'>
$ tramway draw map -i my_file.rwa
```

The *bayes_factor* plugin admits the following arguments:

* `--localization-error` or shorter `-e` (default value: 0)
* `--B-threshold` or shorter `-b` (default value set by `calculate_bayes_factors_for_one_cell`)