### PR TITLE
NumPy and SciPy fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: [3.8, 3.9, 3.11]
       fail-fast: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Unit tests and code coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 jobs:
   unittests:
@@ -18,8 +18,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        #python-version: [3.6, 3.7, 3.8, 3.9]
-        python-version: [3.6, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
       fail-fast: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 
-name: Unit tests and code coverage
+name: Unit tests
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: [3.8, 3.9, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
 
     steps:
@@ -61,26 +61,3 @@ jobs:
         pytest
         tests/test_core.py
         tests/test_analyzer.py
-
-  coverage:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies and run tests
-      run: |
-        sudo apt-get update
-        sudo apt-get install h5utils
-        python -m pip install --upgrade pip
-        python -m pip install pytest-cov
-        python -m pip install .[roi]
-        python -m pytest --cov=./ \
-          tests/test_core.py \
-          tests/test_analyzer.py
-    - uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[tool.poetry]
+name = "tramway"
+version = "0.6.6"
+description = ""
+authors = ["François Laurent <francois.laurent@pasteur.fr>"]
+license = "CECILL-2.1"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.12"
+six = "^1.16.0"
+numpy = "^1.24.3"
+scipy = "<1.9.2"
+pandas = "^2.0.2"
+matplotlib = "^3.7.1"
+rwa = {path = "../RWA-python", develop = true}
+
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.3.1"
+
+
+[tool.poetry.group.full.dependencies]
+polytope = "^0.2.3"
+paramiko = "^3.2.0"
+stopit = "^1.1.2"
+nbconvert = "^7.4.0"
+bokeh = ">=2.0.2,<2.3.0"
+selenium = "^4.9.1"
+plotly = "^5.14.1"
+nbformat = "^5.9.0"
+opencv-python = "^4.7.0.72"
+scikit-image = "^0.20.0"
+tqdm = "^4.65.0"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,36 @@ scikit-image = "^0.20.0"
 tqdm = "^4.65.0"
 
 
+
+[tool.poetry.group.roi.dependencies]
+polytope = "^0.2.3"
+tqdm = "^4.65.0"
+
+
+[tool.poetry.group.animate.dependencies]
+opencv-python = "^4.7.0.72"
+scikit-image = "^0.20.0"
+tqdm = "^4.65.0"
+
+
+[tool.poetry.group.webui.dependencies]
+bokeh = ">=2.0.2,<2.3.0"
+selenium = "^4.9.1"
+plotly = "^5.14.1"
+nbformat = "^5.9.0"
+
+
+[tool.poetry.group.hpc-minimal.dependencies]
+polytope = "^0.2.3"
+stopit = "^1.1.2"
+
+
+[tool.poetry.group.hpc.dependencies]
+polytope = "^0.2.3"
+paramiko = "^3.2.0"
+stopit = "^1.1.2"
+nbconvert = "^7.4.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,56 +13,34 @@ numpy = "^1.24.3"
 scipy = "<1.9.2"
 pandas = "^2.0.2"
 matplotlib = "^3.7.1"
-rwa = {path = "../RWA-python", develop = true}
+rwa-python = "^0.9.3"
+
+polytope = { version = "^0.2.3", optional = true }
+paramiko = { version = "^3.2.0", optional = true }
+stopit = { version = "^1.1.2", optional = true }
+nbconvert = { version = "^7.4.0", optional = true }
+bokeh = { version = ">=2.0.2,<2.3.0", optional = true }
+selenium = { version = "^4.9.1", optional = true }
+plotly = { version = "^5.14.1", optional = true }
+nbformat = { version = "^5.9.0", optional = true }
+opencv-python = { version = "^4.7.0.72", optional = true }
+scikit-image = { version = "^0.20.0", optional = true }
+tqdm = { version = "^4.65.0", optional = true }
 
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"
 
 
-[tool.poetry.group.full.dependencies]
-polytope = "^0.2.3"
-paramiko = "^3.2.0"
-stopit = "^1.1.2"
-nbconvert = "^7.4.0"
-bokeh = ">=2.0.2,<2.3.0"
-selenium = "^4.9.1"
-plotly = "^5.14.1"
-nbformat = "^5.9.0"
-opencv-python = "^4.7.0.72"
-scikit-image = "^0.20.0"
-tqdm = "^4.65.0"
+[tool.poetry.extras]
+# `full` is for backward compatibility; use --all-extras instead
+full = ["polytope", "paramiko", "stopit", "nbconvert", "bokeh", "selenium", "plotly", "nbformat", "opencv-python", "scikit-image", "tqdm"]
+roi = ["polytope", "tqdm"]
+animate = ["opencv-python", "scikit-image", "tqdm"]
+webui = ["bokeh", "selenium", "plotly", "nbformat"]
+hpc-minimal = ["polytope", "stopit"]
+hpc = ["polytope", "paramiko", "stopit", "nbconvert"]
 
-
-
-[tool.poetry.group.roi.dependencies]
-polytope = "^0.2.3"
-tqdm = "^4.65.0"
-
-
-[tool.poetry.group.animate.dependencies]
-opencv-python = "^4.7.0.72"
-scikit-image = "^0.20.0"
-tqdm = "^4.65.0"
-
-
-[tool.poetry.group.webui.dependencies]
-bokeh = ">=2.0.2,<2.3.0"
-selenium = "^4.9.1"
-plotly = "^5.14.1"
-nbformat = "^5.9.0"
-
-
-[tool.poetry.group.hpc-minimal.dependencies]
-polytope = "^0.2.3"
-stopit = "^1.1.2"
-
-
-[tool.poetry.group.hpc.dependencies]
-polytope = "^0.2.3"
-paramiko = "^3.2.0"
-stopit = "^1.1.2"
-nbconvert = "^7.4.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,12 @@ from os import path
 install_requires = ['six', 'numpy', 'scipy', 'pandas', 'matplotlib', 'rwa-python>=0.8']
 extras_require = {
         'animate':  ['opencv-python', 'scikit-image', 'tqdm'],
-        'roi':  ['polytope', 'cvxopt', 'tqdm'],
+        'roi':  ['polytope', 'tqdm'],
         'webui':    ['bokeh >=2.0.2, <2.3.0', 'selenium', 'plotly', 'nbformat'],
-        'hpc-minimal':  ['polytope', 'cvxopt', 'stopit'],
-        'hpc':  ['polytope', 'cvxopt', 'paramiko', 'stopit', 'nbconvert'],
+        'hpc-minimal':  ['polytope', 'stopit'],
+        'hpc':  ['polytope', 'paramiko', 'stopit', 'nbconvert'],
         'full':  [
-            'polytope', 'cvxopt', 'paramiko', 'stopit', 'nbconvert',
+            'polytope', 'paramiko', 'stopit', 'nbconvert',
             'bokeh >=2.0.2, <2.3.0', 'selenium', 'plotly', 'nbformat',
             'opencv-python', 'scikit-image', 'tqdm',
             ]}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(path.join(pwd, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name = 'tramway',
-    version = '0.6.5',
+    version = '0.6.6',
     description = 'TRamWAy',
     long_description = long_description,
     url = 'https://github.com/DecBayComp/TRamWAy',

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -29,9 +29,9 @@ If the tests fail but no noticeable change can be found, the data archive
 should be updated.
 """
 
-py2_hash, py3_hash = 'MGtbXz14', 'A4l6MXDG'
+py2_hash, py3_hash = 'MGtbXz14', 'R0Wpvakg'
 data_server = 'http://dl.pasteur.fr/fop/{}/'.format(py2_hash if sys.version_info[0] == 2 else py3_hash)
-data_update = '210816'#'210628'#'210126'#'200909'
+data_update = '230602'#'210816'#'210628'#'210126'#'200909'
 data_file = 'glycine_receptor.trxyt'
 
 data_dir = '{}_py{}_{}'.format('test_commandline', sys.version_info[0], data_update)
@@ -68,24 +68,24 @@ def datadir(tmpdir, request):
             try:
                 with tarfile.open(dest) as archive:
                     def is_within_directory(directory, target):
-                        
+
                         abs_directory = os.path.abspath(directory)
                         abs_target = os.path.abspath(target)
-                    
+
                         prefix = os.path.commonprefix([abs_directory, abs_target])
-                        
+
                         return prefix == abs_directory
-                    
+
                     def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-                    
+
                         for member in tar.getmembers():
                             member_path = os.path.join(path, member.name)
                             if not is_within_directory(path, member_path):
                                 raise Exception("Attempted Path Traversal in Tar File")
-                    
-                        tar.extractall(path, members, numeric_owner=numeric_owner) 
-                        
-                    
+
+                        tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
                     safe_extract(archive, tests_dir)
             except:
                 _print(tmpdir, '[failed]')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -131,8 +131,8 @@ class TestXyt(object):
                 tested_result.dtypes.tolist() == expected_result.dtypes.tolist() and \
                 numpy.all(tested_result.index == expected_result.index) and \
                 numpy.allclose(tested_result, expected_result)
-        return pandas.DataFrame([[1,.1,.1,.05],[1,.45,.45,.1],[1,.85,.65,.12],[2,.6,.9,.25],[2,.4,.5,.3]], columns=list('nxyt'))
-        assert crop(self.example_nxyt(), self.example_bbox(), add_deltas=False).equals(expected_result[list('nxyt')])
+        #return pandas.DataFrame([[1,.1,.1,.05],[1,.45,.45,.1],[1,.85,.65,.12],[2,.6,.9,.25],[2,.4,.5,.3]], columns=list('nxyt'))
+        #assert crop(self.example_nxyt(), self.example_bbox(), add_deltas=False).equals(expected_result[list('nxyt')])
 
     def test_reindex(self):
         from io import StringIO

--- a/tramway/core/xyt.py
+++ b/tramway/core/xyt.py
@@ -604,7 +604,7 @@ def reindex_trajectories(trajectories, trajnum_colname="n", dt=None):
                 dt = traj["dt"].min()
             else:
                 dt = traj["t"].diff().min()
-            if dt.size == 0:
+            if isinstance(dt, np.ndarray) and dt.size == 0:
                 dt = None
             elif np.isclose(dt, 0):
                 raise ValueError("multiple rows for the same time point and trajectory")

--- a/tramway/inference/base.py
+++ b/tramway/inference/base.py
@@ -1984,7 +1984,7 @@ def distributed(
 
         # find (trans-)locations for cell j
         i = fuzzy(cells.tessellation, j, *fuzzy_args, **fuzzy_kwargs)
-        if i.dtype in (bool, np.bool8, np.bool_):
+        if i.dtype in (bool, np.bool_):
             _fuzzy[j] = None
         else:
             _fuzzy[j] = i[i != 0]


### PR DESCRIPTION
This PR fixes issue #41 and other numpy/scipy cross-version serialization issues (in package RWA-python).

Python 3.11 is still poorly supported as some dependencies need to be compiled.

Github actions are fixed for Python versions 3.8, 3.9 and 3.10.